### PR TITLE
Center the map (automatically or as requested)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,7 +1,20 @@
 # BioPocket Mobile Application Development Guide
 
-<!-- START doctoc -->
-<!-- END doctoc -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+
+- [Application](#application)
+- [Environment](#environment)
+  - [Implementation](#implementation)
+- [Logging things](#logging-things)
+- [Including CSS files from external modules](#including-css-files-from-external-modules)
+  - [Example : adding the `node_modules/leaflet/dist/leaflet.css` file in the `www/build/leaflet` folder:](#example--adding-the-node_modulesleafletdistleafletcss-file-in-the-wwwbuildleaflet-folder)
+- [Internationalization](#internationalization)
+  - [Message format interpolation](#message-format-interpolation)
+- [RxJS Operators](#rxjs-operators)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
 
@@ -32,6 +45,25 @@ The file for the current environment can be imported like this:
 import { ENV } from '@app/env';
 ```
 
+### Implementation
+
+The `@app/env` module is a [module resolution alias][webpack-resolve] defined by
+augmenting Ionic's default webpack configuration in the following files:
+
+* `config/optimization.config.js`
+* `config/webpack.config.js`
+
+This configuration is applied by the `config.ionic_optimization` and
+`config.ionic_webpack` properties of `package.json`.
+
+For TypeScript to correctly identify the `@app/env` module, the path to the
+environment files has been added to the `compilerOptions.paths` property of the
+`tsconfig.json` file at the root of the project.
+
+This mechanism is based on [Easy to use environment variables for Ionic3!][ionic-env-vars].
+
+
+
 ## Logging things
 
 When in need of logging things in the application, refrain from using the javascript `console` utility.
@@ -59,22 +91,7 @@ Print.debug(Print);
 Print.error('Ooops');
 ```
 
-### Implementation
 
-The `@app/env` module is a [module resolution alias][webpack-resolve] defined by
-augmenting Ionic's default webpack configuration in the following files:
-
-* `config/optimization.config.js`
-* `config/webpack.config.js`
-
-This configuration is applied by the `config.ionic_optimization` and
-`config.ionic_webpack` properties of `package.json`.
-
-For TypeScript to correctly identify the `@app/env` module, the path to the
-environment files has been added to the `compilerOptions.paths` property of the
-`tsconfig.json` file at the root of the project.
-
-This mechanism is based on [Easy to use environment variables for Ionic3!][ionic-env-vars].
 
 ## Including CSS files from external modules
 
@@ -119,6 +136,7 @@ module.exports = {
 > For the file to be actually copied, you need to restart the server (or rebuild the app)
 
 **When the needed files are copied in the `www` directory, they can be referenced in the `index.html` or in a component.**
+
 
 
 ## Internationalization
@@ -206,6 +224,22 @@ translateService.get({ RES: 2, CAT: 2 })
 ```
 
 See the [format guide][messageformat-guide] for more information.
+
+
+
+## RxJS Operators
+
+The RxJS library does not import all operators by default.
+All operators used in code, e.g. `map`, `switchMap`, etc, must be referenced in the `src/app/rxjs.ts` file.
+
+This file is already imported:
+
+* In the application module in `src/app/app.module.ts`, meaning RxJS operators will be available in development code.
+* In the `spec/chai.ts` test file which is included by most test files to use chai expectations with plugins.
+
+If you do not import `spec/chai.ts` and your test does not import the application module either,
+you might have a warning that some RxJS operators are not available.
+In that case, import `src/app/rxjs.ts` to solve the issue.
 
 
 

--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ to refresh the app.
 
 ### Scripts
 
-| Script                    | Purpose                                                           |
-| :---                      | :---                                                              |
-| `npm start`               | Initialize & start the app with `ionic serve`                     |
-| `npm run doctoc`          | Generate the table of contents of this README                     |
-| `npm run locales`         | Compile the .yml locale files to TypeScript once                  |
-| `npm run locales:start`   | Compile the .yml locale files to TypeScript and watch for changes |
-| `npm run locales:watch`   | Compile the .yml locale files when changes occur                  |
-| `npm run test`            | Run all unit & end-to-end tests once                              |
-| `npm run test:watch`      | Run all unit & end-to-end tests and watch for changes             |
-| `npm run test:unit`       | Run unit tests once                                               |
-| `npm run test:unit:watch` | Run unit tests and watch for changes                              |
-| `npm run test:e2e`        | Run end-to-end tests once                                         |
-| `npm run test:e2e:watch`  | Run end-to-end tests when changes occur                           |
+| Script                    | Purpose                                                                 |
+| :---                      | :---                                                                    |
+| `npm start`               | Initialize & start the app with `ionic serve`                           |
+| `npm run doctoc`          | Generate the table of contents of this README and the DEVELOPMENT guide |
+| `npm run locales`         | Compile the .yml locale files to TypeScript once                        |
+| `npm run locales:start`   | Compile the .yml locale files to TypeScript and watch for changes       |
+| `npm run locales:watch`   | Compile the .yml locale files when changes occur                        |
+| `npm run test`            | Run all unit & end-to-end tests once                                    |
+| `npm run test:watch`      | Run all unit & end-to-end tests and watch for changes                   |
+| `npm run test:unit`       | Run unit tests once                                                     |
+| `npm run test:unit:watch` | Run unit tests and watch for changes                                    |
+| `npm run test:e2e`        | Run end-to-end tests once                                               |
+| `npm run test:e2e:watch`  | Run end-to-end tests when changes occur                                 |

--- a/config.xml
+++ b/config.xml
@@ -82,4 +82,7 @@
     <plugin name="cordova-plugin-device" spec="^1.1.4" />
     <plugin name="cordova-plugin-splashscreen" spec="^4.0.3" />
     <plugin name="cordova-plugin-ionic-webview" spec="^1.1.16" />
+    <plugin name="cordova-plugin-geolocation" spec="^3.0.0">
+        <variable name="GEOLOCATION_USAGE_DESCRIPTION" value="To locate you" />
+    </plugin>
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,11 @@
       "resolved": "https://registry.npmjs.org/@ionic-native/core/-/core-3.12.1.tgz",
       "integrity": "sha512-cncRlkun1lwJ0kZUs7jrDbmHDvHNdveJhdsgJT7nGLavbK54UN3CdBjMcAk7zNOqlil6nXY8Nn/2B6WpUmQRNg=="
     },
+    "@ionic-native/geolocation": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@ionic-native/geolocation/-/geolocation-4.5.2.tgz",
+      "integrity": "sha512-XCrUB1BJaGrzoWJ6rCQZSfslbRMiqB0ROU5XZOyYdg7Yf+DIX9o6qernDSRl9yHJ7c7QhI1XId6x5PHgZjNP/w=="
+    },
     "@ionic-native/splash-screen": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/@ionic-native/splash-screen/-/splash-screen-3.12.1.tgz",
@@ -182,6 +187,1191 @@
       "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-8.0.0.tgz",
       "integrity": "sha1-dR/WtRLYDzp0jS3o38lt/vopr+A="
     },
+    "@turf/along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-5.1.5.tgz",
+      "integrity": "sha1-YdbmplhKzdq1asVYTge/jL5fi+s=",
+      "requires": {
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/area": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-5.1.5.tgz",
+      "integrity": "sha1-79iZv9Jgzb0VQbKjwVX4pdLu+h0=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/bbox": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-5.1.5.tgz",
+      "integrity": "sha1-MFHfUUrUxQ9KT5uKLRX9i2hA7aM=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/bbox-clip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-clip/-/bbox-clip-5.1.5.tgz",
+      "integrity": "sha1-M2S1Mo3/nzz0HZ4C7a/zdNFQzIQ=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "lineclip": "1.1.5"
+      }
+    },
+    "@turf/bbox-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-5.1.5.tgz",
+      "integrity": "sha1-auuk7VHYXSluD3w4uIwznwHu4CQ=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-5.1.5.tgz",
+      "integrity": "sha1-egt5ATbE70eX8CRjBdRcvi0ns/c=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/bezier-spline": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/bezier-spline/-/bezier-spline-5.1.5.tgz",
+      "integrity": "sha1-WaJ7ul17l+8Vqz/VpA+9I4cEm8o=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/boolean-clockwise": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-5.1.5.tgz",
+      "integrity": "sha1-MwK32sYsXikaB4nimvcoM4f6nes=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/boolean-contains": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-5.1.5.tgz",
+      "integrity": "sha1-WW1jruY2961T7pn5/yTJaZSg7xQ=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/boolean-crosses": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-crosses/-/boolean-crosses-5.1.5.tgz",
+      "integrity": "sha1-Ab+uollvFk3kpNMlCU3HwlXHFdY=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/polygon-to-line": "5.1.5"
+      }
+    },
+    "@turf/boolean-disjoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-5.1.5.tgz",
+      "integrity": "sha1-MDzw2i52lGfmanRuXMRVOUw1gek=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/polygon-to-line": "5.1.5"
+      }
+    },
+    "@turf/boolean-equal": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-equal/-/boolean-equal-5.1.5.tgz",
+      "integrity": "sha1-Kfj21gu4RQff12WzIlTbjnLJOKQ=",
+      "requires": {
+        "@turf/clean-coords": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "@turf/boolean-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-5.1.5.tgz",
+      "integrity": "sha1-DU5kxSx3CijpPZ7834qLg3OsznU=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/line-overlap": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "geojson-equality": "0.1.6"
+      }
+    },
+    "@turf/boolean-parallel": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-parallel/-/boolean-parallel-5.1.5.tgz",
+      "integrity": "sha1-c5NYR16ltlx+GCejw+DopofTqF0=",
+      "requires": {
+        "@turf/clean-coords": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/rhumb-bearing": "5.1.5"
+      }
+    },
+    "@turf/boolean-point-in-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-5.1.5.tgz",
+      "integrity": "sha1-8BzBlNHgMKVIv9qYHLpDz9YpQbc=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/boolean-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-5.1.5.tgz",
+      "integrity": "sha1-9jPF/4Aq0ku48Vja269v9KAj3Xs=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/boolean-within": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-5.1.5.tgz",
+      "integrity": "sha1-RxBdVtB1Kp0Pv81Dw2pfkUnchpc=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/buffer": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-5.1.5.tgz",
+      "integrity": "sha1-hByWJ8+5dLEirE4alW8EZrwCMcQ=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/projection": "5.1.5",
+        "d3-geo": "1.7.1",
+        "turf-jsts": "1.2.2"
+      }
+    },
+    "@turf/center": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-5.1.5.tgz",
+      "integrity": "sha1-RKss2VT2PA03dX9xWKmcPvURS4A=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/center-mean": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-mean/-/center-mean-5.1.5.tgz",
+      "integrity": "sha1-jI6YdTkeXwnw5uePXWYbiLIQigo=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/center-median": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-median/-/center-median-5.1.5.tgz",
+      "integrity": "sha1-u0Yb/noqSGAdikcnaFcYcjoUqHI=",
+      "requires": {
+        "@turf/center-mean": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/center-of-mass": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/center-of-mass/-/center-of-mass-5.1.5.tgz",
+      "integrity": "sha1-TTvXnYhJjbq4Mk1PafAyL2Uguco=",
+      "requires": {
+        "@turf/centroid": "5.1.5",
+        "@turf/convex": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/centroid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-5.1.5.tgz",
+      "integrity": "sha1-d4radCFjNQIa2P0OemWoNJ1Tx2k=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-5.1.5.tgz",
+      "integrity": "sha1-mxV3g1UIq1L7HBCypQZcuiuHtqU=",
+      "requires": {
+        "@turf/destination": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/clean-coords": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clean-coords/-/clean-coords-5.1.5.tgz",
+      "integrity": "sha1-EoAKmKeMmkUqcuxChJPEOs8q2h8=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/clone": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-5.1.5.tgz",
+      "integrity": "sha1-JT6NNUdxgZduM636tQoPAqfw42c=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/clusters": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters/-/clusters-5.1.5.tgz",
+      "integrity": "sha1-ZzpeXxsZycq6vFfJCO6t1oIiTdQ=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/clusters-dbscan": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-dbscan/-/clusters-dbscan-5.1.5.tgz",
+      "integrity": "sha1-V4H7TmVsdHoLjpk333MYHAMJ4m8=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "density-clustering": "1.3.0"
+      }
+    },
+    "@turf/clusters-kmeans": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/clusters-kmeans/-/clusters-kmeans-5.1.5.tgz",
+      "integrity": "sha1-/W3+qLEzuovcI3CsPKzuFYejAvE=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "skmeans": "0.9.7"
+      }
+    },
+    "@turf/collect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/collect/-/collect-5.1.5.tgz",
+      "integrity": "sha1-/pjJqMIY7PJP/DPXApUXt8GbKj4=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "rbush": "2.0.1"
+      }
+    },
+    "@turf/combine": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/combine/-/combine-5.1.5.tgz",
+      "integrity": "sha1-uxS976VVBDVxlfwaEkzX1TqMiQU=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/concave": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/concave/-/concave-5.1.5.tgz",
+      "integrity": "sha1-I7uqw4fQNLlldKG9cNBZI3qdIRA=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/tin": "5.1.5",
+        "topojson-client": "3.0.0",
+        "topojson-server": "3.0.0"
+      }
+    },
+    "@turf/convex": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/convex/-/convex-5.1.5.tgz",
+      "integrity": "sha1-Dfk3fdACIWzpghsH9wXgN9rj4B0=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "concaveman": "1.1.1"
+      }
+    },
+    "@turf/destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-5.1.5.tgz",
+      "integrity": "sha1-7TU4G9zoO73cvQei4rzivd/7zCY=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/difference": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-5.1.5.tgz",
+      "integrity": "sha1-ok1pCnvKgD8QkKnuO52Qb8Q3H0I=",
+      "requires": {
+        "@turf/area": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "turf-jsts": "1.2.2"
+      }
+    },
+    "@turf/dissolve": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/dissolve/-/dissolve-5.1.5.tgz",
+      "integrity": "sha1-LPEzqQIdIWODHD16lY1lB/nYGTg=",
+      "requires": {
+        "@turf/boolean-overlap": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/union": "5.1.5",
+        "geojson-rbush": "2.1.0",
+        "get-closest": "0.0.4"
+      }
+    },
+    "@turf/distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-5.1.5.tgz",
+      "integrity": "sha1-Oc8YIEu/h1h9cH5gmmARiQkVZAk=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-5.1.5.tgz",
+      "integrity": "sha1-1XyrhTmFkgzeYCKKeNgEWAJcVL4=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/transform-rotate": "5.1.5"
+      }
+    },
+    "@turf/envelope": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/envelope/-/envelope-5.1.5.tgz",
+      "integrity": "sha1-UBMwnFP91D369LWIplw/7X28EIo=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/bbox-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/explode": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/explode/-/explode-5.1.5.tgz",
+      "integrity": "sha1-sSsvd0AEobSPYrqVsgocZVo94Rg=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/flatten": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flatten/-/flatten-5.1.5.tgz",
+      "integrity": "sha1-2iknBnEz7WFpsLnWB7khVoiqE1g=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/flip": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/flip/-/flip-5.1.5.tgz",
+      "integrity": "sha1-Q29kOnIvDKU7n85jjkaT2zYIpoo=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/great-circle": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/great-circle/-/great-circle-5.1.5.tgz",
+      "integrity": "sha1-3r+2cc5HVQnLY3MBwV/PzPo1mpM=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/helpers": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-5.1.5.tgz",
+      "integrity": "sha1-FTQFInq5M9AEpbuWQantmZ/L4M8="
+    },
+    "@turf/hex-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/hex-grid/-/hex-grid-5.1.5.tgz",
+      "integrity": "sha1-m3ul/s9QUfHoWJL3E/zlxVBQKmo=",
+      "requires": {
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/intersect": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/interpolate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/interpolate/-/interpolate-5.1.5.tgz",
+      "integrity": "sha1-DxLwq3VtbdEK+ykMpuh3ve8BPqo=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/hex-grid": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/point-grid": "5.1.5",
+        "@turf/square-grid": "5.1.5",
+        "@turf/triangle-grid": "5.1.5"
+      }
+    },
+    "@turf/intersect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-5.1.5.tgz",
+      "integrity": "sha1-EhJh2vqEe1QI2CRfH1X9uy90S3o=",
+      "requires": {
+        "@turf/clean-coords": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/truncate": "5.1.5",
+        "turf-jsts": "1.2.2"
+      }
+    },
+    "@turf/invariant": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-5.1.5.tgz",
+      "integrity": "sha1-9Z9P76CSJLFdzhZR+QPIaNV6JOE=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/isobands": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isobands/-/isobands-5.1.5.tgz",
+      "integrity": "sha1-a0TO9YTVUaMTBBh68jtKFYLj8I0=",
+      "requires": {
+        "@turf/area": "5.1.5",
+        "@turf/bbox": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/explode": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/isolines": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/isolines/-/isolines-5.1.5.tgz",
+      "integrity": "sha1-irTn9Cuz38VGFOW/FVln9+VdLeE=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/kinks": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/kinks/-/kinks-5.1.5.tgz",
+      "integrity": "sha1-irtpYdm7AQchO63fLCwmQNAlaYA=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/length": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-5.1.5.tgz",
+      "integrity": "sha1-86X4ZMK5lqi7RxeUU1ofrxLuvvs=",
+      "requires": {
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/line-arc": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-arc/-/line-arc-5.1.5.tgz",
+      "integrity": "sha1-AHinRHg1oSrkFKIR+aZNEYYVDhU=",
+      "requires": {
+        "@turf/circle": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/line-chunk": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-chunk/-/line-chunk-5.1.5.tgz",
+      "integrity": "sha1-kQqFwFwG2dD5w4l3oF4IGNUIXEI=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/length": "5.1.5",
+        "@turf/line-slice-along": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/line-intersect": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-5.1.5.tgz",
+      "integrity": "sha1-DikHGuQDKV5JFyO8SfXPrI0R3fM=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-offset": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-offset/-/line-offset-5.1.5.tgz",
+      "integrity": "sha1-KrWy8In4yRPiMdmUN4553KkLWh4=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/line-overlap": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-5.1.5.tgz",
+      "integrity": "sha1-lDxvh6A4bcQ9+sEdKz/5wRLNP2A=",
+      "requires": {
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/nearest-point-on-line": "5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-segment": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-5.1.5.tgz",
+      "integrity": "sha1-Mgeq7lRqskw9jcPMY/kcdwuAE+U=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/line-slice": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice/-/line-slice-5.1.5.tgz",
+      "integrity": "sha1-Hs/OFGKjeFeXVM7fRGTN4mgp8rU=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/nearest-point-on-line": "5.1.5"
+      }
+    },
+    "@turf/line-slice-along": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-slice-along/-/line-slice-along-5.1.5.tgz",
+      "integrity": "sha1-7drQoh70efKWihG9LdcomiEy6aU=",
+      "requires": {
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/line-split": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-split/-/line-split-5.1.5.tgz",
+      "integrity": "sha1-Wy30w3YZty73JbUWPPmSbVVArLc=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/nearest-point-on-line": "5.1.5",
+        "@turf/square": "5.1.5",
+        "@turf/truncate": "5.1.5",
+        "geojson-rbush": "2.1.0"
+      }
+    },
+    "@turf/line-to-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/line-to-polygon/-/line-to-polygon-5.1.5.tgz",
+      "integrity": "sha1-ITz0Gmj4Ikd4ujnTGH3sPouBhlo=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/mask": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/mask/-/mask-5.1.5.tgz",
+      "integrity": "sha1-mrD+8aJyyY/j70kvn/thggayQtU=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/union": "5.1.5",
+        "rbush": "2.0.1"
+      }
+    },
+    "@turf/meta": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-5.1.6.tgz",
+      "integrity": "sha1-wgqGPt7Qhp+yhUje6Ik0G8y0akY=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/midpoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/midpoint/-/midpoint-5.1.5.tgz",
+      "integrity": "sha1-4mH2srDqgSTM7/VSomLdRlydBfA=",
+      "requires": {
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/nearest-point": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point/-/nearest-point-5.1.5.tgz",
+      "integrity": "sha1-EgUN5Bw5hEMiTHl43g9iE5ANNPs=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/nearest-point-on-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-5.1.5.tgz",
+      "integrity": "sha1-VgauKX8VlHUkvqUaKp71HsG/nDY=",
+      "requires": {
+        "@turf/bearing": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/nearest-point-to-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-to-line/-/nearest-point-to-line-5.1.5.tgz",
+      "integrity": "sha1-4Z5L52+3Dscu8e/OtQ71eqIRTGY=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/point-to-line-distance": "5.1.5"
+      }
+    },
+    "@turf/planepoint": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/planepoint/-/planepoint-5.1.5.tgz",
+      "integrity": "sha1-GLvfAG91ne9eQsagBsn53oGyt/8=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/point-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-grid/-/point-grid-5.1.5.tgz",
+      "integrity": "sha1-MFFBJI9Quv42zn5mukuX56sjaIc=",
+      "requires": {
+        "@turf/boolean-within": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/point-on-feature": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-on-feature/-/point-on-feature-5.1.5.tgz",
+      "integrity": "sha1-MMfwMkMCd8ZBjZbSieRba/shP+c=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/explode": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/nearest-point": "5.1.5"
+      }
+    },
+    "@turf/point-to-line-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-5.1.5.tgz",
+      "integrity": "sha1-L+Vp3MmNERFlIqPJk75pXqwG+ik=",
+      "requires": {
+        "@turf/bearing": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/projection": "5.1.5",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5"
+      }
+    },
+    "@turf/points-within-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/points-within-polygon/-/points-within-polygon-5.1.5.tgz",
+      "integrity": "sha1-K4VaXfOq2lfC7oIKB1SrlJKKIzc=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/polygon-tangents": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-tangents/-/polygon-tangents-5.1.5.tgz",
+      "integrity": "sha1-K/AJkUcwJbF44lDcfLmuVAm71lI=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/polygon-to-line": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-5.1.5.tgz",
+      "integrity": "sha1-I7tEjYTcTGUZmaxhGjbZHFklA2o=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/polygonize": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/polygonize/-/polygonize-5.1.5.tgz",
+      "integrity": "sha1-BJP6EYefOdELmtAs5qI+lC0IqjI=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/envelope": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/projection": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-5.1.5.tgz",
+      "integrity": "sha1-JFF+7rLzaBa6n3EueubWo2jt91c=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/random": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/random/-/random-5.1.5.tgz",
+      "integrity": "sha1-sy78k0Vgroulfo67UfJBw5+6Lns=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/rewind": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-5.1.5.tgz",
+      "integrity": "sha1-nqPbSmi3PB/R3RH1djGxQ8/vock=",
+      "requires": {
+        "@turf/boolean-clockwise": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/rhumb-bearing": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-5.1.5.tgz",
+      "integrity": "sha1-rPalAkJ+uMSeGM2mrg7/qwxd3NI=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/rhumb-destination": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-5.1.5.tgz",
+      "integrity": "sha1-sbKuuSFUfyrAwamUtqEw+SRjx0I=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/rhumb-distance": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-5.1.5.tgz",
+      "integrity": "sha1-GAaFdiX0IlOE2tQT5p85U4/192U=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/sample": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sample/-/sample-5.1.5.tgz",
+      "integrity": "sha1-6ctEikeJzFbuPeLdZ4HiNDQ1tBE=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/sector": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/sector/-/sector-5.1.5.tgz",
+      "integrity": "sha1-rCu5TBPt1gNPb9wrZwCBNdIPXgc=",
+      "requires": {
+        "@turf/circle": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/line-arc": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/shortest-path": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/shortest-path/-/shortest-path-5.1.5.tgz",
+      "integrity": "sha1-hUroCW9rw+EwD6ynfz6PZ9j5Nas=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/bbox-polygon": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/clean-coords": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/transform-scale": "5.1.5"
+      }
+    },
+    "@turf/simplify": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/simplify/-/simplify-5.1.5.tgz",
+      "integrity": "sha1-Csjyei60IYGD7dmZjDJ1q+QIuSY=",
+      "requires": {
+        "@turf/clean-coords": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/square": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square/-/square-5.1.5.tgz",
+      "integrity": "sha1-qnsh5gM8ySUsOlvW89iNq9b+0YA=",
+      "requires": {
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/square-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/square-grid/-/square-grid-5.1.5.tgz",
+      "integrity": "sha1-G9X3uesU8LYLwjH+/nNR0aMvGlE=",
+      "requires": {
+        "@turf/boolean-contains": "5.1.5",
+        "@turf/boolean-overlap": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/intersect": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/standard-deviational-ellipse": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/standard-deviational-ellipse/-/standard-deviational-ellipse-5.1.5.tgz",
+      "integrity": "sha1-hc0oO14ayljyG9ZkEuQUtW2FIyQ=",
+      "requires": {
+        "@turf/center-mean": "5.1.5",
+        "@turf/ellipse": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/points-within-polygon": "5.1.5"
+      }
+    },
+    "@turf/tag": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tag/-/tag-5.1.5.tgz",
+      "integrity": "sha1-0e4aUIjs/UoUEQGcmCOczypJfSA=",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/tesselate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tesselate/-/tesselate-5.1.5.tgz",
+      "integrity": "sha1-MqWU6cIaAEIKn5DSxD3z4RZgYc0=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "earcut": "2.1.2"
+      }
+    },
+    "@turf/tin": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/tin/-/tin-5.1.5.tgz",
+      "integrity": "sha1-KCI+r8X76a6azKgc3P6l0UJMkX0=",
+      "requires": {
+        "@turf/helpers": "5.1.5"
+      }
+    },
+    "@turf/transform-rotate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-5.1.5.tgz",
+      "integrity": "sha1-0Jbt2eMA/jFQadVNjkWMQJIh7fs=",
+      "requires": {
+        "@turf/centroid": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5"
+      }
+    },
+    "@turf/transform-scale": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-5.1.5.tgz",
+      "integrity": "sha1-cP064BhWz3uunxWtVhzf6PiQAbk=",
+      "requires": {
+        "@turf/bbox": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5"
+      }
+    },
+    "@turf/transform-translate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-5.1.5.tgz",
+      "integrity": "sha1-Uwolf7Hccmja3Ks05nkB6yo97GM=",
+      "requires": {
+        "@turf/clone": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/rhumb-destination": "5.1.5"
+      }
+    },
+    "@turf/triangle-grid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/triangle-grid/-/triangle-grid-5.1.5.tgz",
+      "integrity": "sha1-ezZ2IQhVTBTyjK/zxIsc/ILI3IE=",
+      "requires": {
+        "@turf/distance": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/intersect": "5.1.5",
+        "@turf/invariant": "5.1.5"
+      }
+    },
+    "@turf/truncate": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/truncate/-/truncate-5.1.5.tgz",
+      "integrity": "sha1-nu37Oxi6gfLJjT6tCUMcyhiErYk=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6"
+      }
+    },
+    "@turf/turf": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-5.1.6.tgz",
+      "integrity": "sha1-wxIlkoh+0jS3VGi4qMRb+Ib7+PY=",
+      "requires": {
+        "@turf/along": "5.1.5",
+        "@turf/area": "5.1.5",
+        "@turf/bbox": "5.1.5",
+        "@turf/bbox-clip": "5.1.5",
+        "@turf/bbox-polygon": "5.1.5",
+        "@turf/bearing": "5.1.5",
+        "@turf/bezier-spline": "5.1.5",
+        "@turf/boolean-clockwise": "5.1.5",
+        "@turf/boolean-contains": "5.1.5",
+        "@turf/boolean-crosses": "5.1.5",
+        "@turf/boolean-disjoint": "5.1.5",
+        "@turf/boolean-equal": "5.1.5",
+        "@turf/boolean-overlap": "5.1.5",
+        "@turf/boolean-parallel": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/boolean-point-on-line": "5.1.5",
+        "@turf/boolean-within": "5.1.5",
+        "@turf/buffer": "5.1.5",
+        "@turf/center": "5.1.5",
+        "@turf/center-mean": "5.1.5",
+        "@turf/center-median": "5.1.5",
+        "@turf/center-of-mass": "5.1.5",
+        "@turf/centroid": "5.1.5",
+        "@turf/circle": "5.1.5",
+        "@turf/clean-coords": "5.1.5",
+        "@turf/clone": "5.1.5",
+        "@turf/clusters": "5.1.5",
+        "@turf/clusters-dbscan": "5.1.5",
+        "@turf/clusters-kmeans": "5.1.5",
+        "@turf/collect": "5.1.5",
+        "@turf/combine": "5.1.5",
+        "@turf/concave": "5.1.5",
+        "@turf/convex": "5.1.5",
+        "@turf/destination": "5.1.5",
+        "@turf/difference": "5.1.5",
+        "@turf/dissolve": "5.1.5",
+        "@turf/distance": "5.1.5",
+        "@turf/ellipse": "5.1.5",
+        "@turf/envelope": "5.1.5",
+        "@turf/explode": "5.1.5",
+        "@turf/flatten": "5.1.5",
+        "@turf/flip": "5.1.5",
+        "@turf/great-circle": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/hex-grid": "5.1.5",
+        "@turf/interpolate": "5.1.5",
+        "@turf/intersect": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "@turf/isobands": "5.1.5",
+        "@turf/isolines": "5.1.5",
+        "@turf/kinks": "5.1.5",
+        "@turf/length": "5.1.5",
+        "@turf/line-arc": "5.1.5",
+        "@turf/line-chunk": "5.1.5",
+        "@turf/line-intersect": "5.1.5",
+        "@turf/line-offset": "5.1.5",
+        "@turf/line-overlap": "5.1.5",
+        "@turf/line-segment": "5.1.5",
+        "@turf/line-slice": "5.1.5",
+        "@turf/line-slice-along": "5.1.5",
+        "@turf/line-split": "5.1.5",
+        "@turf/line-to-polygon": "5.1.5",
+        "@turf/mask": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "@turf/midpoint": "5.1.5",
+        "@turf/nearest-point": "5.1.5",
+        "@turf/nearest-point-on-line": "5.1.5",
+        "@turf/nearest-point-to-line": "5.1.5",
+        "@turf/planepoint": "5.1.5",
+        "@turf/point-grid": "5.1.5",
+        "@turf/point-on-feature": "5.1.5",
+        "@turf/point-to-line-distance": "5.1.5",
+        "@turf/points-within-polygon": "5.1.5",
+        "@turf/polygon-tangents": "5.1.5",
+        "@turf/polygon-to-line": "5.1.5",
+        "@turf/polygonize": "5.1.5",
+        "@turf/projection": "5.1.5",
+        "@turf/random": "5.1.5",
+        "@turf/rewind": "5.1.5",
+        "@turf/rhumb-bearing": "5.1.5",
+        "@turf/rhumb-destination": "5.1.5",
+        "@turf/rhumb-distance": "5.1.5",
+        "@turf/sample": "5.1.5",
+        "@turf/sector": "5.1.5",
+        "@turf/shortest-path": "5.1.5",
+        "@turf/simplify": "5.1.5",
+        "@turf/square": "5.1.5",
+        "@turf/square-grid": "5.1.5",
+        "@turf/standard-deviational-ellipse": "5.1.5",
+        "@turf/tag": "5.1.5",
+        "@turf/tesselate": "5.1.5",
+        "@turf/tin": "5.1.5",
+        "@turf/transform-rotate": "5.1.5",
+        "@turf/transform-scale": "5.1.5",
+        "@turf/transform-translate": "5.1.5",
+        "@turf/triangle-grid": "5.1.5",
+        "@turf/truncate": "5.1.5",
+        "@turf/union": "5.1.5",
+        "@turf/unkink-polygon": "5.1.5",
+        "@turf/voronoi": "5.1.5"
+      }
+    },
+    "@turf/union": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-5.1.5.tgz",
+      "integrity": "sha1-UyhbYJQEf8WNlqrA6pCGXsNNRUs=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "turf-jsts": "1.2.2"
+      }
+    },
+    "@turf/unkink-polygon": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/unkink-polygon/-/unkink-polygon-5.1.5.tgz",
+      "integrity": "sha1-ewGEfFD7V0riV54Z5Ey6hSbSE8M=",
+      "requires": {
+        "@turf/area": "5.1.5",
+        "@turf/boolean-point-in-polygon": "5.1.5",
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "rbush": "2.0.1"
+      }
+    },
+    "@turf/voronoi": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@turf/voronoi/-/voronoi-5.1.5.tgz",
+      "integrity": "sha1-6FbpQG3MLyXWbdyJhYTifC6/ymY=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/invariant": "5.1.5",
+        "d3-voronoi": "1.1.2"
+      }
+    },
     "@types/chai": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.4.tgz",
@@ -246,6 +1436,16 @@
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-2.3.3.tgz",
       "integrity": "sha512-bnoHhhCsx0p0yhLOywFg6T7Le37JjtnzLcWal6cuSPvIZUBzKRIsqM6E5OsKUIRVErCaBCghHIZmqtyGk5uXyA==",
       "dev": true
+    },
+    "@types/sinon-chai": {
+      "version": "2.7.29",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-2.7.29.tgz",
+      "integrity": "sha512-EkI/ZvJT4hglWo7Ipf9SX+J+R9htNOMjW8xiOhce7+0csqvgoF5IXqY5Ae1GqRgNtWCuaywR5HjVa1snkTqpOw==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "4.0.4",
+        "@types/sinon": "2.3.3"
+      }
     },
     "abbrev": {
       "version": "1.1.0",
@@ -1678,6 +2878,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1803,8 +3004,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
-      "dev": true
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
     },
     "component-bind": {
       "version": "1.0.0",
@@ -1870,6 +3070,18 @@
             "safe-buffer": "5.1.1"
           }
         }
+      }
+    },
+    "concaveman": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/concaveman/-/concaveman-1.1.1.tgz",
+      "integrity": "sha1-bCSCWAslI874L8K+wAoEFebmgWI=",
+      "requires": {
+        "monotone-convex-hull-2d": "1.0.1",
+        "point-in-polygon": "1.0.1",
+        "rbush": "2.0.1",
+        "robust-orientation": "1.1.3",
+        "tinyqueue": "1.2.3"
       }
     },
     "concurrently": {
@@ -2246,6 +3458,11 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-device/-/cordova-plugin-device-1.1.4.tgz",
       "integrity": "sha1-1f50cSBp0D9tOG7wvTIbOr0NONw="
     },
+    "cordova-plugin-geolocation": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-geolocation/-/cordova-plugin-geolocation-3.0.0.tgz",
+      "integrity": "sha1-5j4NRXwaL7qw3AKd3qZbjwSSFBA="
+    },
     "cordova-plugin-ionic-webview": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/cordova-plugin-ionic-webview/-/cordova-plugin-ionic-webview-1.1.16.tgz",
@@ -2496,6 +3713,24 @@
         "es5-ext": "0.10.30"
       }
     },
+    "d3-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.1.tgz",
+      "integrity": "sha512-CyINJQ0SOUHojDdFDH4JEM0552vCR1utGyLHegJHyYH0JyCpSeTPxi4OBqHMA2jJZq4NH782LtaJWBImqI/HBw=="
+    },
+    "d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "requires": {
+        "d3-array": "1.2.1"
+      }
+    },
+    "d3-voronoi": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.2.tgz",
+      "integrity": "sha1-Fodmfo8TotFYyAwUgMWinLDYlzw="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2559,6 +3794,11 @@
         "type-detect": "4.0.3"
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2609,6 +3849,11 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
+    },
+    "density-clustering": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/density-clustering/-/density-clustering-1.3.0.tgz",
+      "integrity": "sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU="
     },
     "depd": {
       "version": "1.1.1",
@@ -2756,6 +4001,11 @@
         "dom-serializer": "0.1.0",
         "domelementtype": "1.3.0"
       }
+    },
+    "earcut": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.2.tgz",
+      "integrity": "sha512-ji2b8qOVwK4WChYTbpKo983518wEqY2wrpkd85Us/LLw+3O7G0jGvGbHgQERuovrv3Cop9cEpiNkhqVQSkgTtA=="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -3573,6 +4823,910 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.7.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "fstream": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
@@ -3640,11 +5794,34 @@
         "is-property": "1.0.2"
       }
     },
+    "geojson-equality": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/geojson-equality/-/geojson-equality-0.1.6.tgz",
+      "integrity": "sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=",
+      "requires": {
+        "deep-equal": "1.0.1"
+      }
+    },
+    "geojson-rbush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-2.1.0.tgz",
+      "integrity": "sha1-O9c745H8ELCuaT2bis6iquC4Oo0=",
+      "requires": {
+        "@turf/helpers": "5.1.5",
+        "@turf/meta": "5.1.6",
+        "rbush": "2.0.1"
+      }
+    },
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
       "dev": true
+    },
+    "get-closest": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/get-closest/-/get-closest-0.0.4.tgz",
+      "integrity": "sha1-JprHdtHmAiqg/Vht1wjop9Miaa8="
     },
     "get-func-name": {
       "version": "2.0.0",
@@ -5235,6 +7412,11 @@
         "unreachable-branch-transform": "0.3.0"
       }
     },
+    "lineclip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/lineclip/-/lineclip-1.1.5.tgz",
+      "integrity": "sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM="
+    },
     "livereload-js": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
@@ -5854,6 +8036,14 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
       "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
+    "monotone-convex-hull-2d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
+      "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+      "requires": {
+        "robust-orientation": "1.1.3"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -6235,6 +8425,7 @@
           "requires": {
             "anymatch": "1.3.2",
             "async-each": "1.0.1",
+            "fsevents": "1.1.3",
             "glob-parent": "2.0.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
@@ -6579,6 +8770,11 @@
         "pinkie": "2.0.4"
       }
     },
+    "point-in-polygon": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.0.1.tgz",
+      "integrity": "sha1-1Ztk6P7kHElFiqyCtWcYxZV7Kvc="
+    },
     "postcss": {
       "version": "5.2.17",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
@@ -6822,6 +9018,11 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "quickselect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.0.0.tgz",
+      "integrity": "sha1-AmMIGPmq5OyrJvAQP5jQYcF8WPM="
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -6886,6 +9087,14 @@
       "requires": {
         "bytes": "1.0.0",
         "string_decoder": "0.10.31"
+      }
+    },
+    "rbush": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-2.0.1.tgz",
+      "integrity": "sha1-TPrKKMMGS8DudUMaG3mZDode76k=",
+      "requires": {
+        "quickselect": "1.0.0"
       }
     },
     "read-pkg": {
@@ -7178,6 +9387,36 @@
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
       }
+    },
+    "robust-orientation": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
+      "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+      "requires": {
+        "robust-scale": "1.0.2",
+        "robust-subtract": "1.0.0",
+        "robust-sum": "1.0.0",
+        "two-product": "1.0.2"
+      }
+    },
+    "robust-scale": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
+      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "requires": {
+        "two-product": "1.0.2",
+        "two-sum": "1.0.0"
+      }
+    },
+    "robust-subtract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
+      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+    },
+    "robust-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
+      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
     },
     "rollup": {
       "version": "0.42.0",
@@ -7550,6 +9789,17 @@
         "text-encoding": "0.6.4",
         "type-detect": "4.0.3"
       }
+    },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "dev": true
+    },
+    "skmeans": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/skmeans/-/skmeans-0.9.7.tgz",
+      "integrity": "sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg=="
     },
     "slash": {
       "version": "1.0.0",
@@ -8112,6 +10362,11 @@
         }
       }
     },
+    "tinyqueue": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
+    },
     "tmp": {
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
@@ -8138,6 +10393,22 @@
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
+    },
+    "topojson-client": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.0.0.tgz",
+      "integrity": "sha1-H5kpOnfvQqRI0DKoGqmCtz82DS8=",
+      "requires": {
+        "commander": "2.11.0"
+      }
+    },
+    "topojson-server": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topojson-server/-/topojson-server-3.0.0.tgz",
+      "integrity": "sha1-N4546Hw5cqe1vixdYENptrrmnF4=",
+      "requires": {
+        "commander": "2.11.0"
+      }
     },
     "tough-cookie": {
       "version": "2.3.2",
@@ -8351,12 +10622,27 @@
         "safe-buffer": "5.1.1"
       }
     },
+    "turf-jsts": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.2.tgz",
+      "integrity": "sha1-uZkjZZpGc3uBQT7P+b1w42C6F1M="
+    },
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
+    },
+    "two-product": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
+      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+    },
+    "two-sum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
+      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "clean": "ionic-app-scripts clean",
     "build": "npm run locales && ionic-app-scripts build",
-    "doctoc": "doctoc --notitle --github README.md",
+    "doctoc": "doctoc --notitle --github README.md DEVELOPMENT.md",
     "ionic:build": "npm run locales && cross-env IONIC_ENV=prod ionic-app-scripts build",
     "ionic:serve": "npm run locales && ionic-app-scripts serve",
     "lint": "ionic-app-scripts lint",
@@ -41,13 +41,16 @@
     "@angular/platform-browser-dynamic": "4.1.3",
     "@asymmetrik/ngx-leaflet": "^2.5.3",
     "@ionic-native/core": "3.12.1",
+    "@ionic-native/geolocation": "^4.5.2",
     "@ionic-native/splash-screen": "3.12.1",
     "@ionic-native/status-bar": "3.12.1",
     "@ionic/storage": "2.0.1",
     "@ngx-translate/core": "^8.0.0",
+    "@turf/turf": "^5.1.6",
     "angular2-moment": "^1.7.0",
     "cordova-android": "6.3.0",
     "cordova-plugin-device": "^1.1.4",
+    "cordova-plugin-geolocation": "^3.0.0",
     "cordova-plugin-ionic-webview": "^1.1.16",
     "cordova-plugin-splashscreen": "^4.0.3",
     "cordova-plugin-whitelist": "^1.3.1",
@@ -69,6 +72,7 @@
     "@types/leaflet": "^1.2.3",
     "@types/mocha": "^2.2.42",
     "@types/sinon": "^2.3.3",
+    "@types/sinon-chai": "^2.7.29",
     "angular2-template-loader": "^0.6.2",
     "bluebird": "^3.5.0",
     "chai": "^4.1.2",
@@ -97,6 +101,7 @@
     "onchange": "^3.2.1",
     "protractor": "^5.1.2",
     "sinon": "^3.2.1",
+    "sinon-chai": "^2.14.0",
     "ts-loader": "^2.3.4",
     "ts-node": "^3.3.0",
     "typescript": "2.3.4"
@@ -109,7 +114,10 @@
       "cordova-plugin-whitelist": {},
       "cordova-plugin-device": {},
       "cordova-plugin-splashscreen": {},
-      "cordova-plugin-ionic-webview": {}
+      "cordova-plugin-ionic-webview": {},
+      "cordova-plugin-geolocation": {
+        "GEOLOCATION_USAGE_DESCRIPTION": "To locate you"
+      }
     },
     "platforms": [
       "android"

--- a/spec/chai.ts
+++ b/spec/chai.ts
@@ -1,8 +1,18 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import * as sinonChai from 'sinon-chai';
+
+// This import is here because it is required for any test of code
+// which uses RxJS operators, and most test files import this file,
+// so this is a good central location to put it.
+import '../src/app/rxjs';
 
 // Extend Chai with assertions about promises
 // (see https://github.com/domenic/chai-as-promised)
 chai.use(chaiAsPromised);
+
+// Extend Chai with Sinon assertions
+// (see https://github.com/domenic/sinon-chai)
+chai.use(sinonChai);
 
 export const expect = chai.expect;

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -8,15 +8,15 @@ import { By } from '@angular/platform-browser';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 import { MomentModule } from 'angular2-moment';
 import { LeafletModule } from '@asymmetrik/ngx-leaflet';
-import { expect } from 'chai';
 import { IonicModule, Platform } from 'ionic-angular';
+import { Geolocation } from '@ionic-native/geolocation';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 import moment from 'moment';
 import { TranslateService } from '@ngx-translate/core';
 import { spy, stub } from 'sinon';
 
-
+import { expect } from '../../spec/chai';
 import { createPlatformMock } from '../../spec/mocks';
 import { Deferred, restoreSpyOrStub } from '../../spec/utils';
 import { ENV as MockEnv } from '../environments/environment.test';
@@ -71,6 +71,7 @@ describe('AppComponent', () => {
         LocationsModule
       ],
       providers: [
+        Geolocation,
         { provide: Platform, useValue: platformMock },
         { provide: SplashScreen, useValue: splashScreenMock },
         { provide: StatusBar, useValue: statusBarMock },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,11 +3,12 @@ import { ErrorHandler, NgModule } from '@angular/core';
 import { MomentModule } from 'angular2-moment';
 import { LeafletModule } from '@asymmetrik/ngx-leaflet';
 import { IonicApp, IonicErrorHandler, IonicModule } from 'ionic-angular';
+import { Geolocation } from '@ionic-native/geolocation';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 
 // RXJS Operators
-import 'rxjs/add/operator/map';
+import './rxjs';
 
 import { HomePage } from '../pages/home/home';
 import { MapPage } from '../pages/map/map';
@@ -39,6 +40,7 @@ import EnvService from '../providers/env-service/env-service';
     MapPage
   ],
   providers: [
+    Geolocation,
     StatusBar,
     SplashScreen,
     { provide: ErrorHandler, useClass: IonicErrorHandler },

--- a/src/app/rxjs.ts
+++ b/src/app/rxjs.ts
@@ -1,0 +1,2 @@
+// RXJS Operators
+import 'rxjs/add/operator/map';

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -8,3 +8,4 @@ pages:
     title: "Liste"
   map:
     title: "Carte"
+    geolocation: "Finding your position..."

--- a/src/locales/fr.yml
+++ b/src/locales/fr.yml
@@ -8,4 +8,5 @@ pages:
     title: "Liste"
   map:
     title: "Carte"
-    geolocation: "Finding your position..."
+    geolocation: "Localisation en cours..."
+    geolocationError: "Échec de la localisation"

--- a/src/pages/map/map.html
+++ b/src/pages/map/map.html
@@ -8,9 +8,21 @@
 </ion-header>
 
 <ion-content>
+
   <div id="map"
     leaflet
     [leafletOptions]="mapOptions"
     [leafletLayers]="layers"
     (leafletMapReady)="onMapReady($event)"></div>
+
+  <div id="map-controls">
+    <div class="center-on-me control" [style.color]="isGeolocationInProgress() ? 'lightgray' : 'black'" (click)="centerOnMe()">
+      <ion-icon name="locate"></ion-icon>
+    </div>
+  </div>
+
+  <p *ngIf="mapMessage" id="map-message">
+    {{ mapMessage }}
+  </p>
+
 </ion-content>

--- a/src/pages/map/map.scss
+++ b/src/pages/map/map.scss
@@ -1,3 +1,57 @@
 #map {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
   height: 100%;
+}
+
+#map-controls {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2000;
+  pointer-events: none;
+
+  .control {
+    position: absolute;
+    width: 45px;
+    height: 45px;
+    text-align: center;
+    background-color: white;
+    border-radius: 45px;
+    cursor: pointer;
+    pointer-events: auto;
+
+    &:hover {
+      opacity: 0.7;
+    }
+
+    ion-icon {
+      margin-top: 2.5px;
+      font-size: 40px;
+    }
+  }
+
+  .center-on-me {
+    top: 10px;
+    right: 10px;
+  }
+}
+
+#map-message {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  margin: 0;
+  padding: 0.4em;
+  width: 100%;
+  pointer-events: none;
+  opacity: 0.7;
+  background-color: #000000;
+  color: #ffffff;
+  z-index: 1000;
+  text-align: center;
 }

--- a/src/pages/map/map.spec.ts
+++ b/src/pages/map/map.spec.ts
@@ -1,28 +1,39 @@
 // Mocha global variables (for Windows)
 /// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
 
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Http, ConnectionBackend, Response, ResponseOptions } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';
 import { LeafletModule } from '@asymmetrik/ngx-leaflet';
-import { expect } from 'chai';
 import { IonicModule, NavController } from 'ionic-angular';
+import { Geolocation } from '@ionic-native/geolocation';
 import * as L from 'leaflet';
-import { spy } from 'sinon';
+import { TranslateService } from '@ngx-translate/core';
+import { spy, stub } from 'sinon';
 
+import { Deferred } from '../../../spec/utils';
 import { ENV as MockEnv } from '../../environments/environment.test';
+import { fr } from '../../locales';
 import Marker from '../../models/marker';
 import EnvService from '../../providers/env-service/env-service';
 import locationsDataMock from '../../providers/locations-service/locations-data.mock';
 import LocationsModule from '../../providers/locations-service/locations-module';
+import { expect } from '../../../spec/chai';
 import { translateModuleForRoot } from '../../utils/i18n';
 import { MapPage } from './map';
 
 describe('MapPage', function () {
   let component, fixture, backend;
+  let geolocationMock, geolocationDeferred;
   let navControllerMock;
 
   beforeEach(function () {
+
+    geolocationDeferred = new Deferred();
+    geolocationMock = {
+      getCurrentPosition: stub().returns(geolocationDeferred.promise)
+    };
+
     navControllerMock = {};
 
     TestBed.configureTestingModule({
@@ -36,12 +47,17 @@ describe('MapPage', function () {
         LocationsModule
       ],
       providers: [
+        { provide: Geolocation, useValue: geolocationMock },
         { provide: NavController, useValue: navControllerMock },
         { provide: EnvService, useValue: MockEnv },
         Http,
         { provide: ConnectionBackend, useClass: MockBackend }
       ]
     });
+
+    const translateService = TestBed.get(TranslateService);
+    translateService.setTranslation('fr', fr);
+    translateService.use('fr');
 
     fixture = TestBed.createComponent(MapPage);
     component = fixture.componentInstance;
@@ -72,6 +88,7 @@ describe('MapPage', function () {
 
       expect(component.map).to.equal(undefined);
 
+      // This test lets Leaflet initialize a real map in the view.
       fixture.detectChanges();
       await fixture.whenStable();
 
@@ -131,7 +148,7 @@ describe('MapPage', function () {
 
       expect(markerIds).to.have.members(expectedIds);
 
-      component.map.setView([12, 4], 13);
+      component.map.setView([12, 4], 15);
 
       const callOptions = {
         bbox: component.map.getBounds().toBBoxString()
@@ -139,7 +156,7 @@ describe('MapPage', function () {
 
       fixture.detectChanges();
       await fixture.whenStable();
-      
+
       expect(spyFetchAll.callCount).to.equal(2);
       expect(spyFetchAll.getCall(1).args[0]).to.eql(callOptions);
 
@@ -148,5 +165,136 @@ describe('MapPage', function () {
 
       expect(markerIds).to.have.members(expectedIds);
     });
+
+    describe('and initialized', function() {
+
+      let map, setViewSpy;
+      beforeEach(function() {
+
+        // The tests in this describe block use a Leaflet map that is manually
+        // instantiated here rather than in the view.
+        map = L.map('map');
+        setViewSpy = spy(map, 'setView');
+
+        expect(geolocationMock.getCurrentPosition).to.have.callCount(0);
+        expect(setViewSpy).to.have.callCount(0);
+
+        expect(component.mapMessage).to.equal(undefined);
+
+        component.onMapReady(map);
+
+        expect(geolocationMock.getCurrentPosition).to.have.callCount(1);
+        expectMapViewSet(setViewSpy.args[0], [ 46.183541, 6.100234 ], 15);
+        expect(setViewSpy).to.have.callCount(1);
+
+        expect(component.mapMessage).to.equal(fr.pages.map.geolocation);
+      });
+
+      it('should automatically center the map on the user if in Onex', fakeAsync(function() {
+
+        geolocationDeferred.resolve({ coords: { longitude: 6.09, latitude: 46.18 } });
+        tick();
+
+        expect(component.mapMessage).to.equal(undefined);
+
+        expectMapViewSet(setViewSpy.args[1], L.latLng(46.18, 6.09), 15, { animate: true });
+        expect(setViewSpy).to.have.callCount(2);
+      }));
+
+      it('should leave the map centered on Onex if the user is not there', fakeAsync(function() {
+
+        geolocationDeferred.resolve({ coords: { longitude: 8, latitude: 48 } });
+        tick();
+
+        expect(component.mapMessage).to.equal(undefined);
+
+        expectMapViewSet(setViewSpy.args[0], [ 46.183541, 6.100234 ], 15);
+        expect(setViewSpy).to.have.callCount(1);
+      }));
+
+      it('should leave the map centered on Onex if the user cannot be located', fakeAsync(function() {
+
+        geolocationDeferred.reject(new Error('Dunno where you are'));
+        tick();
+
+        expect(component.mapMessage).to.equal(undefined);
+        expect(setViewSpy).to.have.callCount(1);
+      }));
+
+      it('should center the map on the user\'s current position when clicking on the center me button', fakeAsync(function() {
+
+        geolocationDeferred.resolve({ coords: { longitude: 1, latitude: 0 } });
+        tick();
+
+        expect(component.mapMessage).to.equal(undefined);
+
+        expectMapViewSet(setViewSpy.args[0], [ 46.183541, 6.100234 ], 15);
+        expect(setViewSpy).to.have.callCount(1);
+
+        const currentPositionDeferred = new Deferred();
+        geolocationMock.getCurrentPosition.onCall(1).returns(currentPositionDeferred.promise);
+
+        component.centerOnMe();
+
+        expect(component.mapMessage).to.equal(fr.pages.map.geolocation);
+
+        currentPositionDeferred.resolve({ coords: { longitude: 24, latitude: 42 } });
+        tick();
+
+        expect(component.mapMessage).to.equal(undefined);
+
+        expectMapViewSet(setViewSpy.args[1], L.latLng(42, 24), 15, { animate: true });
+        expect(setViewSpy).to.have.callCount(2);
+      }));
+
+      it('should center the map on the user\'s initial position when clicking on the center me button before the initial position has been determined', fakeAsync(function() {
+
+        const currentPositionDeferred = new Deferred();
+        geolocationMock.getCurrentPosition.onCall(1).returns(currentPositionDeferred.promise);
+
+        const nextPositionDeferred = new Deferred();
+        geolocationMock.getCurrentPosition.onCall(2).returns(nextPositionDeferred.promise);
+
+        // Click before initial position has been determined.
+        component.centerOnMe();
+
+        geolocationDeferred.resolve({ coords: { longitude: 6.09, latitude: 46.18 } });
+        tick();
+
+        expect(setViewSpy).to.have.callCount(2);
+        expectMapViewSet(setViewSpy.args[1], L.latLng(46.18, 6.09), 15, { animate: true });
+        expect(component.mapMessage).to.equal(undefined);
+
+        currentPositionDeferred.resolve({ coords: { longitude: 24, latitude: 42 } });
+        tick();
+
+        expect(setViewSpy).to.have.callCount(2);
+        expect(component.mapMessage).to.equal(undefined);
+      }));
+    });
+
+    function expectMapViewSet(actual, coordinates, zoom, options?: any) {
+
+      if (coordinates instanceof L.LatLng) {
+        expect(actual[0]).to.be.an.instanceof(L.LatLng);
+        expect(actual[0].lng).to.equal(coordinates.lng);
+        expect(actual[0].lat).to.equal(coordinates.lat);
+      } else {
+        expect(actual[0]).to.eql(coordinates);
+      }
+
+      expect(actual[1]).to.equal(zoom);
+
+      const actualOptions = actual[2];
+      if (options) {
+        for (let property in options) {
+          expect(actualOptions[property], `options.${property}`).to.eql(options[property]);
+        }
+      } else {
+        expect(actualOptions).to.equal(undefined);
+      }
+
+      expect(actual).to.have.lengthOf.at.most(3);
+    }
   });
 });

--- a/src/pages/map/map.ts
+++ b/src/pages/map/map.ts
@@ -1,15 +1,24 @@
 import { Component } from '@angular/core';
-import { NavController } from 'ionic-angular';
+import { Geolocation } from '@ionic-native/geolocation';
 import * as L from 'leaflet';
 import { intersectionBy, differenceBy } from 'lodash';
+import { TranslateService } from '@ngx-translate/core';
+import * as turf from '@turf/turf';
 
 import { Location } from '../../models/location';
+import Marker from '../../models/marker';
 import LocationsService from '../../providers/locations-service/locations-service';
+import { turfPointToLeafletLatLng } from '../../utils/geo';
 import { defIcon } from '../../utils/leafletIcons';
 import Print from '../../utils/print';
-import Marker from '../../models/marker';
 
 const LOG_REF: string = "[MapPage]";
+
+const ONEX_SOUTH_WEST = turf.point([ 6.086417, 46.173987 ]);
+const ONEX_NORTH_EAST = turf.point([ 6.112753, 46.196898 ]);
+const ONEX_BBOX = turf.bboxPolygon(turf.bbox(turf.featureCollection([ ONEX_SOUTH_WEST, ONEX_NORTH_EAST ])));
+
+type UserPosition = turf.Feature<turf.Point>;
 
 @Component({
   selector: 'map-page',
@@ -18,10 +27,17 @@ const LOG_REF: string = "[MapPage]";
 export class MapPage {
 
   map: L.Map;
+  mapMessage: string;
   mapOptions: Object;
   layers: Marker[] = [];
 
-  constructor(public navCtrl: NavController, private locationsService: LocationsService) {
+  private geolocationInProgress: boolean;
+
+  constructor(
+    private geolocation: Geolocation,
+    private locationsService: LocationsService,
+    private translateService: TranslateService
+  ) {
     this.mapOptions = {
       layers: [
         L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -29,20 +45,40 @@ export class MapPage {
           maxZoom: 19
         })
       ]
-    }
+    };
   }
 
   /**
    * Triggered when the Leaflet map is ready to be accessed and manipulated
-   * @param {L.Map} map - The Leaflet map 
+   * @param {L.Map} map - The Leaflet map
    */
   onMapReady(map: L.Map) {
+
     this.map = map;
     this.map.setView([46.183541, 6.100234], 15);
     this.map.on('moveend', () => this.onMapMoved());
 
+    this.autoCenterMap();
+
     this.locationsService.fetchAll({ bbox: this.map.getBounds().toBBoxString() })
       .subscribe(locations => this.showLocationsOnMap(locations));
+  }
+
+  /**
+   * Centers the map on the user's current position (unless geolocation is already in progress).
+   */
+  centerOnMe() {
+    if (!this.isGeolocationInProgress()) {
+      this.getCurrentPosition().then(currentPosition => this.centerMap(currentPosition));
+    }
+  }
+
+  /**
+   * Indicates whether the user is currently being geolocated (which happens when the map is
+   * first displayed and every time the user clicks the Center On Me button).
+   */
+  isGeolocationInProgress(): boolean {
+    return this.geolocationInProgress;
   }
 
   /**
@@ -76,6 +112,59 @@ export class MapPage {
    */
   private addLocationToMap(location: Location) {
     this.layers.push(new Marker(location.id, location.geometry.coordinates, { icon: defIcon }));
+  }
+
+  /**
+   * Center the map on the user's current position if in Onex
+   * (otherwise remain at the default position).
+   */
+  private autoCenterMap() {
+    this.getCurrentPosition().then(currentPosition => {
+      if (turf.inside(currentPosition, ONEX_BBOX)) {
+        this.centerMap(currentPosition);
+      }
+    }).catch(() => { /* do nothing */ });
+  }
+
+  /**
+   * Gets the user's current position, displaying a message on the map while it
+   * is being determined.
+   *
+   * @param {function} [action] - An optional action to execute once the position is available.
+   * @returns {Promise<UserPosition>} A GeoJSON point feature.
+   */
+  private getCurrentPosition(): Promise<UserPosition> {
+
+    this.geolocationInProgress = true;
+    this.mapMessage = this.translateService.instant('pages.map.geolocation');
+
+    return this.geolocation
+      .getCurrentPosition()
+      .then(result => {
+        this.setGeolocationDone();
+        return turf.point([ result.coords.longitude, result.coords.latitude ]);
+      }, err => {
+        this.setGeolocationDone();
+        Print.warn('Could not get user position', err);
+        return Promise.reject(err);
+      });
+  }
+
+  /**
+   * Centers the map on the specified position at zoom level 15.
+   *
+   * @param {UserPosition} The position to center the map on.
+   */
+  private centerMap(position: UserPosition) {
+    this.map.setView(turfPointToLeafletLatLng(position), 15, { animate: true });
+  }
+
+  /**
+   * Marks geolocation as complete and hides the corresponding message on the map.
+   */
+  private setGeolocationDone() {
+    this.mapMessage = undefined;
+    this.geolocationInProgress = false;
   }
 
 }

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,0 +1,13 @@
+import * as L from 'leaflet';
+import * as turf from '@turf/turf';
+
+/**
+ * Converts a turf point (or GeoJSON point feature) into a Leaflet LatLng object.
+ */
+export function turfPointToLeafletLatLng(pointOrFeature: turf.Point | turf.Feature<turf.Point>): L.LatLng {
+  if (pointOrFeature.type == 'Feature') {
+    return turfPointToLeafletLatLng(pointOrFeature.geometry);
+  } else {
+    return L.latLng(pointOrFeature.coordinates[1], pointOrFeature.coordinates[0]);
+  }
+}


### PR DESCRIPTION
The turf library was added to work with geometries, and Cordova and
Ionic's geolocation plugin to determine the user's position.

The sinon-chai package was also added to write more readable assertions
on sinon spies/stubs, e.g. `expect(spy).to.have.been.calledWith('foo')`
instead of `expect(spy.calledWith('foo')).to.equal(true)`.

RxJS operator imports were moved to `src/app/rxjs.ts` because apparently
some tests need them too (probably tests that do not import the
application module, which was where those RxJS imports were located).

Story: TG-44