### PR TITLE
Replace legacy Http provider with HttpClient

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8017,11 +8017,6 @@
       "dev": true,
       "optional": true
     },
-    "ng-request-builder": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/ng-request-builder/-/ng-request-builder-0.4.0.tgz",
-      "integrity": "sha512-NJeedNc1xs5aO8jWlSOTHgeW9qxdpfEa+HzgHM4c81qUxs0HYX5/FR1E5vyr5LL76HBWbZRwwcY6lzF0otD73w=="
-    },
     "nise": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "leaflet": "^1.3.1",
     "lodash": "^4.17.4",
     "messageformat": "^1.1.1",
-    "ng-request-builder": "^0.4.0",
     "rxjs": "^5.5.6",
     "sw-toolbox": "^3.6.0",
     "zone.js": "^0.8.20"

--- a/spec/chai.ts
+++ b/spec/chai.ts
@@ -2,10 +2,12 @@ import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
 import * as sinonChai from 'sinon-chai';
 
-// This import is here because it is required for any test of code
+// These imports are here because they are required for any test of code
 // which uses RxJS operators, and most test files import this file,
 // so this is a good central location to put it.
 import '../src/app/rxjs';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/throw';
 
 // Extend Chai with assertions about promises
 // (see https://github.com/domenic/chai-as-promised)

--- a/spec/http.ts
+++ b/spec/http.ts
@@ -1,0 +1,182 @@
+import { HttpHeaders, HttpParams, HttpRequest } from '@angular/common/http';
+import { isEqual, isEmpty } from 'lodash';
+
+import { expect } from './chai';
+
+/**
+ * A single value of an HTTP header or query parameter.
+ */
+export type HeadersOrParamsValue = boolean | number | string;
+
+/**
+ * A plain object that represents the headers or query parameters of an HTTP request. Single or
+ * multiple values of various types are permitted.
+ */
+export type HeadersOrParams = { [name: string]: HeadersOrParamsValue | HeadersOrParamsValue[]; };
+
+/**
+ * A plain object that represents the headers or query parameters of an HTTP request in a normalized
+ * format. The value of a header or param is always a string array.
+ */
+export type NormalizedHeadersOrParams = { [name: string]: string[]; };
+
+/**
+ * Asserts that the specified HTTP request has the expected properties. If not, an error is thrown
+ * describing why the request does not match.
+ *
+ * @param actual The request to check.
+ * @param expectedMethod The method the request should use (e.g. GET, POST).
+ * @param expectedUrl The URL the request should be made to.
+ * @param expectedBody The body the request should have.
+ * @param expectedHeaders The headers the request should have (values are normalized to string arrays, so you can use single values, numbers, etc).
+ * @param expectedParams The query parameters the request should have (values are normalized to string arrays, so you can use single values, numbers, etc).
+ */
+export function assertHttpRequest(actual: HttpRequest<any>, expectedMethod: string, expectedUrl: string, expectedBody?: any, expectedHeaders?: HttpHeaders | HeadersOrParams, expectedParams?: HttpParams | HeadersOrParams): void {
+
+  const actualDescription = describeHttpRequest(actual);
+  if (!actual) {
+    throw new Error(`Expected an HTTP request matching ${actualDescription}, but got ${typeof(actual)}`);
+  }
+
+  const problems = [];
+
+  if (actual.method.toUpperCase() !== expectedMethod.toUpperCase()) {
+    problems.push('method does not match');
+  }
+
+  if (actual.url !== expectedUrl) {
+    problems.push('URL does not match');
+  }
+
+  if (!isEqual(actual.body || null, expectedBody || null)) {
+    problems.push('body does not match');
+  }
+
+  if (!isEqual(normalizeHeadersOrParams(actual.headers), normalizeHeadersOrParams(expectedHeaders))) {
+    problems.push('headers do not match');
+  }
+
+  if (!isEqual(normalizeHeadersOrParams(actual.params), normalizeHeadersOrParams(expectedParams))) {
+    problems.push('params do not match');
+  }
+
+  if (problems.length >= 1) {
+    const expectedDescription = describeHttpRequest(expectedMethod, expectedUrl, expectedBody, expectedHeaders, expectedParams);
+    throw new Error(`Expected an HTTP request matching ${expectedDescription} but got ${actualDescription}: ${problems.join(', ')}`);
+  }
+}
+
+/**
+ * Returns a string describing an HttpRequest object.
+ *
+ * @param req The HTTP request to describe.
+ * @returns A description of the request.
+ */
+export function describeHttpRequest(req: HttpRequest<any>);
+
+/**
+ * Returns a string describing an HTTP request.
+ *
+ * @param method The HTTP method the request uses.
+ * @param url The URL the request is made to.
+ * @param body The body of the request (if any).
+ * @param headers The HTTP headers the request has (if any).
+ * @param params The query parameters the request has (if any).
+ * @returns A description of the request.
+ */
+export function describeHttpRequest(method: string, url: string, body?: any, headers?: HttpHeaders | HeadersOrParams, params?: HttpParams | HeadersOrParams);
+
+export function describeHttpRequest(reqOrMethod: HttpRequest<any> | string, url?: string, body?: any, headers?: HttpHeaders | HeadersOrParams, params?: HttpParams | HeadersOrParams): string {
+
+  let method: string;
+  if (reqOrMethod instanceof HttpRequest) {
+    method = reqOrMethod.method;
+    url = reqOrMethod.url;
+    body = reqOrMethod.body;
+    headers = normalizeHeadersOrParams(reqOrMethod.headers);
+    params = normalizeHeadersOrParams(reqOrMethod.params);
+  } else {
+    method = reqOrMethod;
+    headers = normalizeHeadersOrParams(headers);
+    params = normalizeHeadersOrParams(params);
+  }
+
+  let description = `${method} ${url}`;
+  let details = [];
+
+  if (body) {
+    details.push(`body ${JSON.stringify(body)}`);
+  }
+
+  if (headers && !isEmpty(headers)) {
+    details.push(`headers ${JSON.stringify(headers)}`);
+  }
+
+  if (params && !isEmpty(params)) {
+    details.push(`params ${JSON.stringify(params)}`);
+  }
+
+  if (details.length) {
+    description = `${description} with ${details.join(' and ')}`;
+  }
+
+  return description;
+}
+
+/**
+ * Returns an HTTP request matching function that indicates whether a request has the expected properties.
+ *
+ * Intended for use with HttpTestingController:
+ *
+ *     httpTestingCtrl
+ *       .expectOne(httpRequestMatcher('GET', 'http://example.com/path', { some: 'body' }, { Authorization: 'Bearer changeme' }, { page: 3 }))
+ *       .flush(someResponse);
+ *
+ * @param expectedMethod The method the request should use (e.g. GET, POST).
+ * @param expectedUrl The URL the request should be made to.
+ * @param expectedBody The body the request should have.
+ * @param expectedHeaders The headers the request should have (values are normalized to string arrays, so you can use single values, numbers, etc).
+ * @param expectedParams The query parameters the request should have (values are normalized to string arrays, so you can use single values, numbers, etc).
+ * @returns True (or an error is thrown).
+ */
+export function httpRequestMatcher(expectedMethod: string, expectedUrl: string, expectedBody?: any, expectedHeaders?: HttpHeaders | HeadersOrParams, expectedParams?: HttpParams | HeadersOrParams): (req: HttpRequest<any>) => boolean {
+  return (req: HttpRequest<any>) => {
+    assertHttpRequest(req, expectedMethod, expectedUrl, expectedBody, expectedHeaders, expectedParams);
+    return true;
+  };
+}
+
+/**
+ * Converts an Angular headers or params object to a plain object that has header/param names as
+ * keys and string arrays as values. An empty object is returned if the input is null or undefined.
+ *
+ *     normalizeHeadersOrParams(headers);      // => { "Content-Type": [ "application/json" ] }
+ *     normalizeHeadersOrParams(null);         // => {}
+ *     normalizeHeadersOrParams({ page: 2 });  // => { "page": [ "2" ] }
+ *
+ * This can be used to check, for example, whether headers in different formats are in fact
+ * equivalent (such as an HttpHeaders object and a plain object).
+ *
+ * @param data The Angular headers or params to convert.
+ * @returns A plain object.
+ */
+export function normalizeHeadersOrParams(data: HttpHeaders | HttpParams | HeadersOrParams): NormalizedHeadersOrParams {
+  const result = {};
+
+  if (data instanceof HttpHeaders || data instanceof HttpParams) {
+    for (let name of data.keys()) {
+      result[name] = data.getAll(name).map(value => String(value));
+    }
+  } else if (data) {
+    for (let name in data) {
+      const values = data[name];
+      if (Array.isArray(values)) {
+        result[name] = values.map(value => String(value));
+      } else {
+        result[name] = [ String(values) ];
+      }
+    }
+  }
+
+  return result;
+}

--- a/spec/sinon.ts
+++ b/spec/sinon.ts
@@ -1,0 +1,159 @@
+import { SinonSpy, SinonStub } from 'sinon';
+
+/**
+ * A Sinon spy or stub.
+ */
+export type SinonSpyOrStub = SinonSpy | SinonStub;
+
+/**
+ * A callback function that can be invoked with a Sinon spy or stub as argument.
+ */
+export type SinonSpyOrStubCallback<T extends SinonSpyOrStub> = (spyOrStub: T) => void;
+
+/**
+ * Returns the specified function typed as a Sinon spy.
+ * An error is thrown if the function is in fact not a Sinon spy.
+ *
+ * @param func The Sinon spy function.
+ * @param callbacks A series of callbacks that will be invoked sequentially with the spy if provided.
+ * @returns The Sinon spy.
+ */
+export const asSpy = (func: Function, ...callbacks: SinonSpyOrStubCallback<SinonSpy>[]) => doWithSpy(func, ...callbacks);
+
+/**
+ * Returns the specified function typed as a Sinon stub.
+ * An error is thrown if the function is in fact not a Sinon stub.
+ *
+ * @param func The Sinon stub function.
+ * @param callbacks A series of callbacks that will be invoked sequentially with the stub if provided.
+ * @returns The Sinon stub.
+ */
+export const asStub = (func: Function, ...callbacks: SinonSpyOrStubCallback<SinonStub>[]) => doWithStub(func, ...callbacks);
+
+/**
+ * Returns the specified function typed as a Sinon spy and with its history reset (i.e. any
+ * previously spied calls are cleared).  An error is thrown if the function is in fact not a Sinon
+ * spy.
+ *
+ *     // Create a spy and make some calls.
+ *     const foo = spy();
+ *     foo();
+ *     foo.callCount; // 1
+ *
+ *     // Resetting a spy clears its call history.
+ *     resetSpy(foo);
+ *     foo.callCount; // 0
+ *
+ * @param func The Sinon spy function.
+ * @param callbacks A series of callbacks that will be invoked sequentially with the spy if provided (after reset).
+ * @returns The Sinon spy.
+ */
+export const resetSpy = (func: Function, ...callbacks: SinonSpyOrStubCallback<SinonSpy>[]) => doWithSpy(func, spy => spy.resetHistory(), ...callbacks);
+
+/**
+ * Returns the specified function typed as a Sinon stub and with both its behavior and history reset
+ * (i.e. any previously configured behavior and spied calls are cleared).  An error is thrown if the
+ * function is in fact not a Sinon stub.
+ *
+ *     const foo = stub();
+ *
+ *     // Configure a behavior and make some calls.
+ *     foo.returns("bar");
+ *     foo();          // "bar"
+ *     foo.callCount;  // 1
+ *
+ *     // Resetting the stub clears its behavior and call history.
+ *     resetStub(foo);
+ *     foo.callCount;  // 0
+ *     foo();          // undefined
+ *
+ * @param func The Sinon stub function.
+ * @param callbacks A series of callbacks that will be invoked sequentially with the stub if provided (after reset).
+ * @returns The Sinon stub.
+ */
+export const resetStub = (func: Function, ...callbacks: SinonSpyOrStubCallback<SinonStub>[]) => doWithStub(func, stub => stub.reset(), ...callbacks);
+
+/**
+ * Restores an object method spied with Sinon to its original behavior.
+ * An error is thrown if the method is in fact not a Sinon spy.
+ *
+ *     // Replace an object's method with a spy.
+ *     spy(service, "fetchAll");
+ *     service.fetchAll(); // calls the spy
+ *
+ *     // Restoring the spy puts the original method back.
+ *     restoreSpy(service.fetchAll);
+ *     service.fetchAll(); // calls the original method
+ *
+ * @param method The Sinon spy method to restore.
+ */
+export const restoreSpy = (method: Function) => { doWithSpy(method, spy => spy.restore()); };
+
+/**
+ * Restores an object method stubbed with Sinon to its original behavior.
+ * An error is thrown if the method is in fact not a Sinon stub.
+ *
+ *     // Replace an object's method with a stub.
+ *     stub(service, "fetchAll");
+ *     asStub(service.fetchAll).returns([]);
+ *     service.fetchAll(); // []
+ *
+ *     // Restoring the stub puts the original method back.
+ *     restoreStub(service.fetchAll);
+ *     service.fetchAll(); // calls the original method
+ *
+ * @param method The Sinon stub method to restore.
+ */
+export const restoreStub = (method: Function) => { doWithStub(method, stub => stub.restore()); };
+
+/**
+ * Type guard to check that the specified function is a Sinon spy.
+ *
+ * @param func The function to check.
+ * @returns True if the function is a Sinon spy, false otherwise.
+ */
+function ensureSpy(func: Function): func is SinonSpy {
+  return typeof(func) === 'function' && typeof(func['callCount']) === 'number';
+}
+
+/**
+ * Type guard to check that the specified function is a Sinon stub.
+ *
+ * @param func The function to check.
+ * @returns True if the function is a Sinon stub, false otherwise.
+ */
+function ensureStub(func: Function): func is SinonStub {
+  return ensureSpy(func) && typeof(func['resetBehavior']) === 'function';
+}
+
+/**
+ * Ensures the specified function is a Sinon spy and sequentially invoke each provided callback with it.
+ *
+ * @param func A Sinon spy.
+ * @param callbacks Callbacks to invoke with the Sinon spy as argument.
+ * @returns The Sinon spy.
+ */
+function doWithSpy(func: Function, ...callbacks: SinonSpyOrStubCallback<SinonSpy>[]): SinonSpy {
+  if (!ensureSpy(func)) {
+    throw new Error('Function is not a Sinon spy');
+  } else {
+    callbacks.forEach(callback => callback(func));
+    return func;
+  }
+}
+
+/**
+ * Ensures the specified function is a Sinon stub and sequentially invoke each provided callback with it.
+ *
+ * @param func A Sinon stub.
+ * @param callbacks Callbacks to invoke with the Sinon stub as argument.
+ * @returns The Sinon stub.
+ */
+function doWithStub(func: Function, ...callbacks: SinonSpyOrStubCallback<SinonStub>[]): SinonStub {
+  if (!ensureStub(func)) {
+    throw new Error('Function is not a Sinon stub');
+  } else {
+    callbacks.forEach(callback => callback(func));
+    return func;
+  }
+}

--- a/spec/utils.ts
+++ b/spec/utils.ts
@@ -1,23 +1,4 @@
 /**
- * Calls Sinon's `restore` method on a spy or stub.
- *
- * Using this utility function avoids TypeScript warnings
- * because functions don't have a `restore` property.
- *
- * @param spyOrStub A function that has been spied upon with `sinon.spy`
- *                  or stubbed with `sinon.stub`
- */
-export function restoreSpyOrStub(spyOrStub: (...args: any[]) => any) {
-  if (!spyOrStub) {
-    throw new Error('A function that is a spy or a stub must be provided');
-  } else if (typeof(spyOrStub['restore']) != 'function') {
-    throw new Error('The provided function has not been spied upon or stubbed');
-  }
-
-  spyOrStub['restore']();
-}
-
-/**
  * Deferred object implementation for use in automated tests.
  * Sometimes we need a promise to be resolved when we want it to.
  *

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -18,7 +18,8 @@ import { spy, stub } from 'sinon';
 
 import { expect } from '../../spec/chai';
 import { createPlatformMock } from '../../spec/mocks';
-import { Deferred, restoreSpyOrStub } from '../../spec/utils';
+import { asSpy, restoreSpy } from '../../spec/sinon';
+import { Deferred } from '../../spec/utils';
 import { ENV as MockEnv } from '../environments/environment.test';
 import { fr } from '../locales';
 import { HomePage } from '../pages/home/home';
@@ -27,7 +28,6 @@ import EnvService from '../providers/env-service/env-service';
 import LocationsModule from '../providers/locations-service/locations-module';
 import { translateModuleForRoot } from '../utils/i18n';
 import { AppComponent, MenuItem } from './app.component';
-
 
 describe('AppComponent', () => {
   let fixture;
@@ -83,6 +83,13 @@ describe('AppComponent', () => {
       set: {
         entryComponents: [HomePage, MapPage]
       }
+    }).overrideComponent(MapPage, {
+      set: {
+        // Replacing the map page's template avoids an actual map being rendered. This avoids a lot
+        // of things being triggered in the map page (such as fetching locations) so that we don't
+        // have to worry about mocking it here.
+        template: '<p>Map</p>'
+      }
     });
   });
 
@@ -102,7 +109,7 @@ describe('AppComponent', () => {
   });
 
   afterEach(() => {
-    restoreSpyOrStub(moment.locale);
+    restoreSpy(moment.locale);
   });
 
   it('should be initialized', async () => {
@@ -120,7 +127,7 @@ describe('AppComponent', () => {
     expect(splashScreenMock.hide.called, 'splashScreen.hide called').to.equal(false);
     expect(statusBarMock.styleDefault.called, 'statusBar.styleDefault called').to.equal(false);
 
-    expect(moment.locale['args'], 'moment.locale called').to.eql([['fr']]);
+    expect(asSpy(moment.locale).args, 'moment.locale called').to.eql([['fr']]);
 
     expect(translateService.setDefaultLang.args, 'translateService.setDefaultLang called').to.eql([['fr']]);
     expect(translateService.setTranslation.args, 'translateService.setTranslation called').to.eql([['fr', fr]]);

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
-import { BrowserModule } from '@angular/platform-browser';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { ErrorHandler, NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
 import { MomentModule } from 'angular2-moment';
 import { LeafletModule } from '@asymmetrik/ngx-leaflet';
 import { IonicApp, IonicErrorHandler, IonicModule } from 'ionic-angular';
@@ -13,6 +14,7 @@ import './rxjs';
 import { HomePage } from '../pages/home/home';
 import { MapPage } from '../pages/map/map';
 import LocationDetails from '../popovers/location-details/location-details';
+import { ApiInterceptor } from '../providers/api-interceptor/api-interceptor';
 import LocationsModule from '../providers/locations-service/locations-module';
 import EnvService from '../providers/env-service/env-service';
 import { translateModuleForRoot } from '../utils/i18n';
@@ -47,7 +49,12 @@ import { AppComponent } from './app.component';
     StatusBar,
     SplashScreen,
     { provide: ErrorHandler, useClass: IonicErrorHandler },
-    EnvService
+    EnvService,
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: ApiInterceptor,
+      multi: true
+    }
   ]
 })
 export class AppModule { }

--- a/src/models/location.spec.ts
+++ b/src/models/location.spec.ts
@@ -80,8 +80,8 @@ describe('Location Object', function () {
 
     expect(locationObj.geometry.type, 'locationObj.geometry.type').to.equal(locationData.geometry.type);
     // We swaps coordinates value when creating the Location so that they're in the right order for Leaflet.
-    expect(locationObj.geometry.coordinates[0], 'locationObj.geometry.coordinates[0]').to.equal(locationData.geometry.coordinates[1]);
-    expect(locationObj.geometry.coordinates[1], 'locationObj.geometry.coordinates[1]').to.equal(locationData.geometry.coordinates[0]);
+    expect(locationObj.geometry.coordinates[0], 'locationObj.geometry.coordinates[0]').to.equal(locationData.geometry.coordinates[0]);
+    expect(locationObj.geometry.coordinates[1], 'locationObj.geometry.coordinates[1]').to.equal(locationData.geometry.coordinates[1]);
 
     expect(locationObj.address.street, 'locationObj.address.street').to.equal(locationData.address.street);
     expect(locationObj.address.zipCode, 'locationObj.address.zipCode').to.equal(locationData.address.zipCode);

--- a/src/models/location.ts
+++ b/src/models/location.ts
@@ -69,7 +69,7 @@ class Geometry {
    */
   constructor(data: any) {
     this.type = data.type;
-    this.coordinates = [data.coordinates[1], data.coordinates[0]];
+    this.coordinates = data.coordinates;
   }
 
 }

--- a/src/pages/map/map.ts
+++ b/src/pages/map/map.ts
@@ -121,7 +121,8 @@ export class MapPage {
    * Also adds a callback to react at a click on the marker.
    */
   private addLocationToMap(location: Location) {
-    const marker = new Marker(location.id, location.geometry.coordinates, { icon: defIcon });
+    const coords = location.geometry.coordinates;
+    const marker = new Marker(location.id, [ coords[1], coords[0] ], { icon: defIcon });
     marker.on('click', e => this.onLocationClicked(<L.LeafletMouseEvent>e));
     this.layers.push(marker);
   }

--- a/src/popovers/location-details/location-details.spec.ts
+++ b/src/popovers/location-details/location-details.spec.ts
@@ -6,6 +6,7 @@ import { ConnectionBackend } from '@angular/http';
 import { MockBackend } from '@angular/http/testing';
 import { IonicModule, ViewController, NavParams } from 'ionic-angular';
 import { TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs/Rx';
 import { stub } from 'sinon';
 
 import { expect } from '../../../spec/chai';
@@ -34,11 +35,7 @@ describe('LocationDetails', function () {
     };
 
     locationsServiceMock = {
-      fetchOne: stub().returns({
-        subscribe: callback => {
-          return callback(new Location(locationsDataMock[2]));
-        }
-      })
+      fetchOne: stub().returns(Observable.of(locationsDataMock[2]))
     };
 
     TestBed.configureTestingModule({

--- a/src/providers/api-interceptor/api-interceptor.spec.ts
+++ b/src/providers/api-interceptor/api-interceptor.spec.ts
@@ -1,0 +1,166 @@
+// Mocha global variables (for Windows)
+/// <reference path="../../../node_modules/@types/mocha/index.d.ts" />
+
+import { HttpClient, HttpHeaders, HTTP_INTERCEPTORS, HttpParams, HttpRequest } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { expect } from 'chai';
+import { compact, isEqual } from 'lodash';
+import { Observable } from 'rxjs/Rx';
+
+import { HeadersOrParams, httpRequestMatcher } from '../../../spec/http';
+import EnvService from '../env-service/env-service';
+import { ApiInterceptor } from './api-interceptor';
+
+type EnvServiceMock = Partial<EnvService>;
+
+describe('ApiInterceptor', function () {
+  let envServiceMock: EnvServiceMock;
+  let httpClient: HttpClient;
+  let httpTestingCtrl: HttpTestingController;
+
+  beforeEach(function () {
+    envServiceMock = {
+      environment: 'development',
+      backendUrl: 'https://example.com/api'
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ],
+      providers: [
+        { provide: EnvService, useValue: envServiceMock },
+        // Plug the interceptor in so that we can make HTTP requests
+        // and see if it does its job correctly.
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: ApiInterceptor,
+          multi: true
+        }
+      ]
+    });
+
+    httpClient = TestBed.get(HttpClient);
+    httpTestingCtrl = TestBed.get(HttpTestingController);
+  });
+
+  afterEach(function() {
+    // Make sure no extra HTTP requests were made.
+    httpTestingCtrl.verify();
+  });
+
+  type TestDefinition = {
+    method: string;
+    body?: any;
+    options?: {
+      headers?: HeadersOrParams;
+      params?: HeadersOrParams;
+    }
+  };
+
+  // This array defines various HTTP request parameters to use for the following tests.
+  const tests: TestDefinition[] = [
+    { method: 'DELETE' },
+    { method: 'GET', options: { headers: { Foo: 'Bar', Bar: [ 'Baz', 'Qux' ] }, params: { ping: 'pong' } } },
+    { method: 'HEAD' },
+    { method: 'OPTIONS' },
+    { method: 'PATCH', body: { foo: 'bar' }, options: { headers: { Corge: 'Grault' } } },
+    { method: 'POST', body: { bar: 'baz' }, options: { params: { page: 1, pageSize: 30 } } },
+    { method: 'PUT', body: { baz: 'qux' } }
+  ];
+
+  // The tests in the following block are repeated for each definition in the array above,
+  // in order to test multiple HTTP method/body/headers/params combinations.
+  tests.forEach(testData => {
+
+    /**
+     * Makes a test HTTP request to the specified path or URL.
+     * The HTTP method, request body and options are taken from the current test data (see array above).
+     *
+     * @param pathOrUrl The path or URL of the request.
+     * @returns An observable of the HTTP response.
+     */
+    function makeTestRequest(pathOrUrl: string): Observable<any> {
+      const args = compact([ pathOrUrl, testData.body, testData.options ]);
+      return httpClient[testData.method.toLowerCase()](...args);
+    }
+
+    /**
+     * Returns an HTTP request matching function that indicates whether a request has the expected properties.
+     * The expected body, headers and params are taken from the current test data (see array above).
+     *
+     * Intended for use with HttpTestingController:
+     *
+     *      httpTestingCtrl
+     *        .expectOne(testRequestMatcher('http://example.com/path'))
+     *        .flush(someResponse);
+     *
+     * @param req The request to check.
+     * @param expectedUrl The URL the request should be made to (without params).
+     * @returns True if the request has exactly the expected properties, false otherwise.
+     */
+    function testRequestMatcher(expectedUrl: string): (req: HttpRequest<any>) => boolean {
+      const testReqOptions = testData.options || {};
+      return httpRequestMatcher(testData.method, expectedUrl, testData.body, testReqOptions.headers, testReqOptions.params);
+    }
+
+    const responseBody = Object.freeze({ foo: 'bar' });
+
+    it(`should prepend the backend URL to paths for a ${testData.method} request`, function() {
+
+      const path = '/things';
+
+      let result;
+      makeTestRequest(path).subscribe(res => result = res);
+
+      httpTestingCtrl
+        .expectOne(testRequestMatcher(`${envServiceMock.backendUrl}${path}`))
+        .flush(responseBody);
+
+      expect(result).to.eql(responseBody);
+    });
+
+    it(`should not prepend the backend URL to a full HTTP URL for a ${testData.method} request`, function() {
+
+      const url = 'http://things.com/all';
+
+      let result;
+      makeTestRequest(url).subscribe(res => result = res);
+
+      httpTestingCtrl
+        .expectOne(testRequestMatcher(url))
+        .flush(responseBody);
+
+      expect(result).to.eql(responseBody);
+    });
+
+    it(`should not prepend the backend URL to a full HTTPS URL for a ${testData.method} request`, function() {
+
+      const url = 'https://things.com/all';
+
+      let result;
+      makeTestRequest(url).subscribe(res => result = res);
+
+      httpTestingCtrl
+        .expectOne(testRequestMatcher(url))
+        .flush(responseBody);
+
+      expect(result).to.eql(responseBody);
+    });
+
+    it(`should not prepend the backend URL to a root URL for a ${testData.method} request`, function() {
+
+      const url = '//images/brand.png';
+
+      let result;
+      makeTestRequest(url).subscribe(res => result = res);
+
+      httpTestingCtrl
+        .expectOne(testRequestMatcher(url))
+        .flush(responseBody);
+
+      expect(result).to.eql(responseBody);
+    });
+  });
+});

--- a/src/providers/api-interceptor/api-interceptor.ts
+++ b/src/providers/api-interceptor/api-interceptor.ts
@@ -1,0 +1,38 @@
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+
+import EnvService from '../env-service/env-service';
+
+/**
+ * HTTP interceptor that simplifies requests to the BioPocket API:
+ *
+ * * All requests made to simple paths with no base URL, e.g. `/users`, automatically have the
+ *   backend URL prepended to form the full request URL, e.g. `https://biopocket.ch/api/users`.
+ *   (Note that the request URL is not modified if it starts with `http://`, `https://` or `//`.)
+ */
+@Injectable()
+export class ApiInterceptor implements HttpInterceptor {
+
+  constructor(private envService: EnvService) {}
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+
+    // Automatically prepend the backend URL if the specified URL is a path (e.g. `/users`).
+    const backendUrl = this.envService.backendUrl;
+    const url = request.url.match(/^(?:https?:)?\/\/[^\/]/) ? request.url : `${backendUrl}${request.url}`;
+    request = request.clone({ url });
+
+    // TODO: automatically set the Authorization header when communicating with the BioPocket API
+    if (url.indexOf(backendUrl) === 0) {
+      request = request.clone({
+        setHeaders: {
+          //Authorization: `Bearer changeme`
+        }
+      });
+    }
+
+    return next.handle(request);
+  }
+
+}

--- a/src/providers/api-service/api-module.ts
+++ b/src/providers/api-service/api-module.ts
@@ -1,13 +1,11 @@
 import { NgModule } from "@angular/core";
-import { HttpModule } from "@angular/http";
-import { RequestBuilderModule } from "ng-request-builder";
+import { HttpClientModule } from "@angular/common/http";
 
 import ApiService from "../../providers/api-service/api-service";
 
 @NgModule({
   imports: [
-    RequestBuilderModule,
-    HttpModule
+    HttpClientModule
   ],
   providers: [
     ApiService

--- a/src/providers/api-service/api-service.ts
+++ b/src/providers/api-service/api-service.ts
@@ -1,48 +1,24 @@
 import { Injectable } from '@angular/core';
-import EnvService from '../env-service/env-service';
-import { Response } from '@angular/http';
-import { RequestBuilderService, RequestBuilder } from 'ng-request-builder';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 
 import { ApiVersion } from '../../models';
 
 /**
- * Global service that handles communication with the BioPocket API
- * Should be imported and used by any other service that needs to communicate with the API
+ * API service for generic top-level resources of the BioPocket API.
  */
 @Injectable()
 export default class ApiService {
 
-  constructor(private reqBuilder: RequestBuilderService, private env: EnvService) { }
+  constructor(private httpClient: HttpClient) { }
 
   /**
-   * Returns the backend api url corresponding to the current environment
-   */
-  get url(): string {
-    return this.env.backendUrl;
-  }
-
-  /**
-   * Query the BioPocket API to get information about the current api version
+   * Query the BioPocket API to get information about the current api version.
+   *
    * @returns {Observable<ApiVersion>} An Observable of an ApiVersion object
    */
   public version(): Observable<ApiVersion> {
-    return this.reqBuilder.request(this.env.backendUrl)
-      .execute()
-      .map((res: Response) => {
-        return new ApiVersion(res.json());
-      });
-  }
-
-  /**
-   * Execute a GET request on the API.
-   * The URL upon which the request will be executed is created by the API base URL to which the `resource` value is concatenated.
-   * TODO : This function will certainly be enhanced/changed/splitted later
-   * @param {string} resource - The relative URL representing the API resources that will be queried. Ex: "/locations"
-   * @returns {Observable<Response>} - An Observable of an Http Response.
-   */
-  public get(resource: string): RequestBuilder {
-    return this.reqBuilder.request(this.env.backendUrl + resource)
+    return this.httpClient.get('/').map(data => new ApiVersion(data));
   }
 
 }

--- a/src/providers/locations-service/locations-data.mock.ts
+++ b/src/providers/locations-service/locations-data.mock.ts
@@ -1,3 +1,5 @@
+import { Location } from '../../models/location';
+
 export default [
   {
     id: 'c821bc0f-85b4-44d5-9bbe-a30cf197c30a',
@@ -63,4 +65,4 @@ export default [
     createdAt: '2000-01-01T16:30:00.123Z',
     updatedAt: '2000-02-03T17:00:00.123Z'
   }
-];
+].map(data => new Location(data));

--- a/src/providers/locations-service/locations-module.ts
+++ b/src/providers/locations-service/locations-module.ts
@@ -1,11 +1,11 @@
+import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from "@angular/core";
 
 import LocationsService from "../../providers/locations-service/locations-service";
-import ApiModule from "../../providers/api-service/api-module";
 
 @NgModule({
   imports: [
-    ApiModule
+    HttpClientModule
   ],
   providers: [
     LocationsService

--- a/src/providers/locations-service/locations-service.ts
+++ b/src/providers/locations-service/locations-service.ts
@@ -1,19 +1,22 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 
-import ApiService from '../api-service/api-service';
 import { Location } from '../../models';
 
+export type FetchLocationsParams = {
+  bbox?: string;
+};
+
 /**
- * Handles request on the BioPocket API that are related to the management of Locations of interest 
+ * Handles request on the BioPocket API that are related to the management of Locations of interest.
  */
 @Injectable()
 export default class LocationsService {
 
-  private resourceName: string = '/locations'
+  private resourcePath: string = '/locations'
 
-  constructor(private api: ApiService) { }
+  constructor(private httpClient: HttpClient) { }
 
   /**
    * Fetch all the locations from the backend
@@ -22,15 +25,8 @@ export default class LocationsService {
    * @param {string} options.bbox - A string representing the bbox that the returned points must be within
    * @returns {Observable<Location>} An Observable of a Location array
    */
-  fetchAll(options?: any): Observable<Location[]> {
-    const request = this.api.get(this.resourceName)
-    if (options && options.bbox) request.setSearchParam('bbox', options.bbox);
-    return request.execute()
-      .map((res: Response) => {
-        return res.json().map((locData: Object) => {
-          return new Location(locData);
-        })
-      });
+  fetchAll(params: FetchLocationsParams = {}): Observable<Location[]> {
+    return this.httpClient.get<any[]>(this.resourcePath, { params }).map(data => data.map(parseApiLocation));
   }
 
   /**
@@ -39,11 +35,11 @@ export default class LocationsService {
    * @returns {Observable<Location>} An Observable of a Location
    */
   fetchOne(id: string): Observable<Location> {
-    return this.api.get(`${this.resourceName}/${id}`)
-      .execute()
-      .map((res: Response) => {
-        return new Location(res.json());
-      });
+    return this.httpClient.get(`${this.resourcePath}/${id}`).map(parseApiLocation);
   }
 
+}
+
+function parseApiLocation(data: any): Location {
+  return new Location(data);
 }


### PR DESCRIPTION
Automated tests have had to be updated to the new way of mocking
requests, i.e. using `HttpClientTestingModule` and
`HttpTestingController`.

Formerly, `ApiService` was mostly a utility provider used by other
providers. Now, it's a provider like the others. The generic
functionality it managed (prepending the backend URL to request paths)
is now managed in the new `ApiInterceptorProvider`. Authentication
through the `Authorization` header will later be handled there as well.

Note that unit tests have also been made "more unitary":

* Unit tests for providers should mock HTTP responses, as HTTP calls are
  made in their implementation.
* Unit tests for components should NOT mock HTTP responses, as the calls
  are made in the services. The services themselves should be mocked
  instead. There should be no reason to mock HTTP responses in most (if
  not all) component tests.

The `ng-request-builder` dependency has been removed as it has been made
obsolete by the simpler interface of the new `HttpClient` provider.

An unrelated modification is that the `Geometry` submodel of the
`Location` model was modified to NOT reverse the longitude/latitude
coordinates provided by the API. Since `Geometry` has the same structure
as a GeoJSON point, it's counter-intuitive to not order the coordinates
in the same way. The reversal is done when creating the Leaflet markers
instead, since they use the latitude/longitude order.

Task: TG-107